### PR TITLE
Adiciona configuração básica do JavaFX

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,17 @@ mvn clean package
 
 A geração do JAR criará o artefato em `target/`. A aplicação principal está no pacote `com.uniclinica.controller`.
 
+### Executar interface JavaFX
+
+Para abrir a interface gráfica básica, utilize o plugin JavaFX:
+
+```bash
+mvn javafx:run
+```
+
+Uma janela simples será exibida demonstrando a integração do projeto com JavaFX.
+
 ## Próximos Passos
 1. Implementar as classes de DAO utilizando JDBC.
 2. Criar o schema MySQL e ajustar o `DBConnection` para usar as variáveis de ambiente `DB_USER` e `DB_PASS`.
-3. Construir a interface em JavaFX ou Swing.
+3. Expandir a interface em JavaFX.

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,36 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <!-- Versão do JavaFX utilizada pelo projeto -->
+        <javafx.version>21.0.2</javafx.version>
     </properties>
 
     <dependencies>
-        <!-- Dependências futuras para MySQL e JavaFX -->
+        <!-- Bibliotecas do JavaFX -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <!-- Dependências futuras para MySQL -->
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <configuration>
+                    <mainClass>com.uniclinica.controller.JavaFXApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/com/uniclinica/controller/JavaFXApp.java
+++ b/src/main/java/com/uniclinica/controller/JavaFXApp.java
@@ -1,0 +1,25 @@
+package com.uniclinica.controller;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+
+/**
+ * Ponto de entrada da interface gráfica JavaFX.
+ */
+public class JavaFXApp extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        Label label = new Label("UniClinicaVet - JavaFX");
+        Scene scene = new Scene(label, 400, 200);
+        stage.setTitle("UniClinicaVet");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}


### PR DESCRIPTION
## Summary
- inclui dependências e plugin do JavaFX no `pom.xml`
- cria `JavaFXApp` com uma janela simples
- documenta execução do JavaFX no README

## Testing
- `mvn -q -DskipTests=true package` *(falhou: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684795170a6c8320b64b84c85c4055c1