### PR TITLE
Remove env usage and configure JDBC connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,0 @@
-DB_USER=your_user
-DB_PASS=your_password
-DB_HOST=localhost
-DB_NAME=uniclinicavet

--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 # Sistema de Gerenciamento de Clínica Veterinária
 
-Este projeto oferece uma arquitetura inicial em Java para gerenciar tutores, animais, consultas e exames. A camada de persistência é feita com MySQL via JDBC e a conexão utiliza variáveis de ambiente.
+Este projeto oferece uma arquitetura inicial em Java para gerenciar tutores, animais, consultas e exames. A camada de persistência é feita com MySQL via JDBC.
 
-Crie um arquivo `.env` (ou defina variáveis no seu sistema) contendo:
-
-```bash
-DB_USER=seu_usuario
-DB_PASS=sua_senha
-DB_HOST=localhost
-DB_NAME=uniclinicavet
-```
+A classe `DBConnection` possui os dados de acesso ao banco de dados definidos diretamente no código. Ajuste as constantes `URL`, `USER` e `PASS` conforme a sua instalação do MySQL.
 
 ## Estrutura de Pastas
 ```

--- a/src/main/java/com/uniclinica/util/DBConnection.java
+++ b/src/main/java/com/uniclinica/util/DBConnection.java
@@ -11,13 +11,14 @@ public class DBConnection {
 
     private DBConnection() {}
 
-    public static Connection getConnection() {
-        String host = System.getenv().getOrDefault("DB_HOST", "localhost");
-        String dbName = System.getenv().getOrDefault("DB_NAME", "uniclinicavet");
-        String user = System.getenv("DB_USER");
-        String pass = System.getenv("DB_PASS");
+    private static final String URL = "jdbc:mysql://localhost:3306/uniclinicavet";
+    private static final String USER = "root"; // ajuste conforme suas credenciais
+    private static final String PASS = "";     // ajuste conforme suas credenciais
 
-        String url = String.format("jdbc:mysql://%s/%s", host, dbName);
+    public static Connection getConnection() {
+        String url = URL;
+        String user = USER;
+        String pass = PASS;
         try {
             return DriverManager.getConnection(url, user, pass);
         } catch (SQLException e) {


### PR DESCRIPTION
## Summary
- hardcode MySQL credentials in `DBConnection`
- delete `.env.example`
- update README instructions to reflect new connection approach

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684797c57c008320b932f0244ac45cb9