### PR TITLE
Add run script and IntelliJ configuration

### DIFF
--- a/.idea/runConfigurations/RunApp.xml
+++ b/.idea/runConfigurations/RunApp.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run App" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.uniclinica.controller.App" />
+    <module name="uniclinicavet" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Depois da compilação, a aplicação principal pode ser executada com:
 java -cp out com.uniclinica.controller.App
 ```
 
+### Execução rápida
+
+Para compilar e executar tudo de uma vez existe o script `run.sh`. Ele realiza a
+compilação e chama a classe principal automaticamente. Basta executar:
+
+```bash
+./run.sh
+```
+
+Ao abrir o projeto no IntelliJ é possível rodar esse mesmo script clicando no
+botão de _Run_ do próprio arquivo ou utilizando a configuração "Run App" já
+incluída no repositório.
+
 ### Executar interface JavaFX
 
 Para abrir a interface gráfica básica é necessário ter as bibliotecas do JavaFX disponíveis. Após baixar os JARs, a execução pode ser feita da seguinte forma (ajuste o caminho conforme sua instalação):

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+mkdir -p out
+javac -d out $(find src/main/java -name '*.java' ! -name 'JavaFXApp.java')
+java -cp out com.uniclinica.controller.App


### PR DESCRIPTION
## Summary
- add `run.sh` script for quick compilation and execution
- include IntelliJ run configuration for `com.uniclinica.controller.App`
- document how to use the script and run configuration in `README`

## Testing
- `bash run.sh`

------
https://chatgpt.com/codex/tasks/task_e_68479a29495c8320a407c5359cfced37