### PR TITLE
Add JavaFX run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ compilação e chama a classe principal automaticamente. Basta executar:
 ./run.sh
 ```
 
+Caso queira abrir diretamente a interface JavaFX, defina a variável de ambiente
+`JAVAFX_LIB` apontando para a pasta `lib` do JavaFX e utilize o script
+`run_javafx.sh`:
+
+```bash
+export JAVAFX_LIB=/caminho/para/javafx/lib
+./run_javafx.sh
+```
+
 Ao abrir o projeto no IntelliJ é possível rodar esse mesmo script clicando no
 botão de _Run_ do próprio arquivo ou utilizando a configuração "Run App" já
 incluída no repositório.

--- a/run_javafx.sh
+++ b/run_javafx.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ -z "$JAVAFX_LIB" ]; then
+  echo "Set JAVAFX_LIB to the JavaFX lib directory" >&2
+  exit 1
+fi
+
+mkdir -p out
+javac --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+      -d out $(find src/main/java -name '*.java')
+
+java --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+     -cp out com.uniclinica.controller.JavaFXApp


### PR DESCRIPTION
## Summary
- add a script for running the JavaFX interface
- document how to use this script in README

## Testing
- `./run.sh`
- `JAVAFX_LIB=/path/nao/existe ./run_javafx.sh` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b08881fa483208824813b37c07670