### PR TITLE
Add Maven build for easier terminal usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /out/
 *.iml
 .idea/
+target/

--- a/README.md
+++ b/README.md
@@ -41,9 +41,36 @@ compilação e chama a classe principal automaticamente. Basta executar:
 ./run.sh
 ```
 
+Caso queira abrir diretamente a interface JavaFX, defina a variável de ambiente
+`JAVAFX_LIB` apontando para a pasta `lib` do JavaFX e utilize o script
+`run_javafx.sh`:
+
+```bash
+export JAVAFX_LIB=/caminho/para/javafx/lib
+./run_javafx.sh
+```
+
 Ao abrir o projeto no IntelliJ é possível rodar esse mesmo script clicando no
 botão de _Run_ do próprio arquivo ou utilizando a configuração "Run App" já
 incluída no repositório.
+
+### Usando Maven
+
+Se preferir rodar tudo diretamente pelo terminal do IntelliJ, utilize o Maven,
+que já possui as dependências configuradas no `pom.xml` deste projeto. Os
+comandos principais são:
+
+```bash
+# Executar a aplicação de console
+mvn exec:java
+
+# Abrir a interface JavaFX
+mvn javafx:run
+```
+
+O IntelliJ reconhece automaticamente este projeto Maven, permitindo executar os
+comandos acima no terminal integrado ou criar configurações de execução a partir
+dos objetivos `exec:java` e `javafx:run`.
 
 ### Executar interface JavaFX
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.uniclinica</groupId>
+    <artifactId>uniclinicavet</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <javafx.version>21</javafx.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.uniclinica.controller.App</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>${javafx.version}</version>
+                <configuration>
+                    <mainClass>com.uniclinica.controller.JavaFXApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/run_javafx.sh
+++ b/run_javafx.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ -z "$JAVAFX_LIB" ]; then
+  echo "Set JAVAFX_LIB to the JavaFX lib directory" >&2
+  exit 1
+fi
+
+mkdir -p out
+javac --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+      -d out $(find src/main/java -name '*.java')
+
+java --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+     -cp out com.uniclinica.controller.JavaFXApp


### PR DESCRIPTION
## Summary
- add `pom.xml` with JavaFX setup and exec plugin
- document new Maven commands in the README
- ignore Maven's `target/` directory

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b08881fa483208824813b37c07670