### PR TITLE
Improve README and directory layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /out/
 *.iml
 .idea/
+target/

--- a/README.md
+++ b/README.md
@@ -20,30 +20,48 @@ src/
 
 ## Compilação
 Utilize o JDK (versão 17 ou superior) para compilar manualmente os arquivos fonte.
-Um exemplo simples de compilação via linha de comando é:
+Para rodar somente a aplicação de console, compile excluindo a classe JavaFX:
 
 ```bash
-javac -d out $(find src/main/java -name '*.java')
-```
-
-Depois da compilação, a aplicação principal pode ser executada com:
-
-```bash
+javac -d out $(find src/main/java -name '*.java' ! -name 'JavaFXApp.java')
 java -cp out com.uniclinica.controller.App
 ```
 
-### Execução rápida
-
-Para compilar e executar tudo de uma vez existe o script `run.sh`. Ele realiza a
-compilação e chama a classe principal automaticamente. Basta executar:
+Para a interface JavaFX é necessário informar as bibliotecas do JavaFX:
 
 ```bash
-./run.sh
+javac --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+      -d out $(find src/main/java -name '*.java')
+
+java --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+     -cp out com.uniclinica.controller.JavaFXApp
 ```
 
-Ao abrir o projeto no IntelliJ é possível rodar esse mesmo script clicando no
-botão de _Run_ do próprio arquivo ou utilizando a configuração "Run App" já
-incluída no repositório.
+### Execução rápida com scripts
+
+O repositório inclui scripts Bash para facilitar a compilação e execução:
+
+```bash
+./run.sh                       # compila e roda a aplicação de console
+JAVAFX_LIB=/caminho/javafx/lib ./run_javafx.sh  # compila e roda o JavaFX
+```
+
+### Execução rápida com Maven
+
+Abra o terminal do IntelliJ e utilize o Maven para compilar e executar o projeto.
+Os principais comandos são:
+
+```bash
+# Executar a aplicação de console
+mvn exec:java
+
+# Abrir a interface JavaFX
+mvn javafx:run
+```
+
+O IntelliJ detecta automaticamente o projeto Maven, permitindo rodar os comandos
+acima no terminal integrado ou criar configurações de execução a partir dos
+objetivos `exec:java` e `javafx:run`.
 
 ### Executar interface JavaFX
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,49 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.uniclinica</groupId>
+    <artifactId>uniclinicavet</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <javafx.version>21</javafx.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${javafx.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.uniclinica.controller.App</mainClass>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <configuration>
+                    <mainClass>com.uniclinica.controller.JavaFXApp</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/run_javafx.sh
+++ b/run_javafx.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [ -z "$JAVAFX_LIB" ]; then
+  echo "Set JAVAFX_LIB to the JavaFX lib directory" >&2
+  exit 1
+fi
+
+mkdir -p out
+javac --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+      -d out $(find src/main/java -name '*.java')
+
+java --module-path "$JAVAFX_LIB" --add-modules javafx.controls,javafx.fxml \
+     -cp out com.uniclinica.controller.JavaFXApp


### PR DESCRIPTION
## Summary
- fix manual compilation instructions
- mention helper scripts for running the app
- create empty `src/main/resources` so README matches

## Testing
- `mvn -q -DskipTests=true package` *(fails: command not found)*
- `./run.sh`
- `JAVAFX_LIB=/path/nao/existe ./run_javafx.sh` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b08881fa483208824813b37c07670