### PR TITLE
Add simple Swing scheduling UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ javac -d out $(find src/main/java -name '*.java')
 java -cp out com.uniclinica.controller.App
 ```
 
-Para abrir a interface Swing basta executar a classe `SwingApp`:
+Para abrir a interface Swing com um pequeno formulário de agendamento basta executar a classe `SwingApp`:
 
 ```bash
 javac -d out $(find src/main/java -name '*.java')
@@ -71,7 +71,7 @@ javac -d out $(find src/main/java -name '*.java')
 java -cp out com.uniclinica.controller.SwingApp
 ```
 
-Uma janela simples será exibida demonstrando a integração do projeto com Swing.
+Ao executar, uma janela exibindo um formulário de agendamento de consultas e exames será apresentada.
 
 ## Próximos Passos
 1. Implementar as classes de DAO utilizando JDBC.

--- a/src/main/java/com/uniclinica/controller/AgendamentoFrame.java
+++ b/src/main/java/com/uniclinica/controller/AgendamentoFrame.java
@@ -1,0 +1,93 @@
+package com.uniclinica.controller;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Janela simples para agendar consultas e exames.
+ */
+public class AgendamentoFrame extends JFrame {
+
+    private final JTextField tutorField = new JTextField();
+    private final JTextField animalField = new JTextField();
+    private final JTextField dataField = new JTextField("yyyy-MM-dd");
+    private final JTextField horaField = new JTextField("HH:mm");
+    private final JTextField veterinarioField = new JTextField();
+    private final JTextField exameField = new JTextField();
+    private final JTextArea outputArea = new JTextArea();
+
+    public AgendamentoFrame() {
+        super("Agendar Consulta/Exame");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        createLayout();
+        pack();
+        setLocationRelativeTo(null);
+    }
+
+    private void createLayout() {
+        JPanel form = new JPanel(new GridLayout(0, 2, 5, 5));
+        form.add(new JLabel("Tutor:"));
+        form.add(tutorField);
+        form.add(new JLabel("Animal:"));
+        form.add(animalField);
+        form.add(new JLabel("Data:"));
+        form.add(dataField);
+        form.add(new JLabel("Hora:"));
+        form.add(horaField);
+        form.add(new JLabel("Veterinário:"));
+        form.add(veterinarioField);
+        form.add(new JLabel("Tipo de Exame:"));
+        form.add(exameField);
+
+        JButton agendarBtn = new JButton("Agendar");
+        agendarBtn.addActionListener(new ScheduleListener());
+
+        JPanel top = new JPanel(new BorderLayout());
+        top.add(form, BorderLayout.CENTER);
+        top.add(agendarBtn, BorderLayout.SOUTH);
+
+        outputArea.setEditable(false);
+        JScrollPane scroll = new JScrollPane(outputArea);
+        scroll.setPreferredSize(new Dimension(400, 200));
+
+        getContentPane().setLayout(new BorderLayout(5, 5));
+        getContentPane().add(top, BorderLayout.NORTH);
+        getContentPane().add(scroll, BorderLayout.CENTER);
+    }
+
+    private class ScheduleListener implements ActionListener {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            try {
+                String tutor = tutorField.getText();
+                String animal = animalField.getText();
+                LocalDate data = LocalDate.parse(dataField.getText(), DateTimeFormatter.ISO_LOCAL_DATE);
+                LocalTime hora = LocalTime.parse(horaField.getText(), DateTimeFormatter.ofPattern("HH:mm"));
+                String vet = veterinarioField.getText();
+                String exame = exameField.getText();
+                LocalDateTime dt = LocalDateTime.of(data, hora);
+
+                String resumo = String.format("%s - %s\n  Consulta: %s com %s\n  Exame: %s\n", tutor, animal, dt, vet, exame);
+                outputArea.append(resumo + "\n");
+
+                // limpa campos
+                tutorField.setText("");
+                animalField.setText("");
+                dataField.setText("yyyy-MM-dd");
+                horaField.setText("HH:mm");
+                veterinarioField.setText("");
+                exameField.setText("");
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(AgendamentoFrame.this,
+                        "Dados inválidos: " + ex.getMessage(),
+                        "Erro", JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+}

--- a/src/main/java/com/uniclinica/controller/SwingApp.java
+++ b/src/main/java/com/uniclinica/controller/SwingApp.java
@@ -1,9 +1,7 @@
 package com.uniclinica.controller;
 
-import javax.swing.JFrame;
-import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
-import java.awt.BorderLayout;
+import com.uniclinica.controller.AgendamentoFrame;
 
 /**
  * Ponto de entrada da interface gráfica Swing.
@@ -11,11 +9,7 @@ import java.awt.BorderLayout;
 public class SwingApp {
 
     private static void createAndShowGui() {
-        JFrame frame = new JFrame("UniClinicaVet");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.add(new JLabel("UniClinicaVet - Swing", JLabel.CENTER), BorderLayout.CENTER);
-        frame.setSize(400, 200);
-        frame.setLocationRelativeTo(null);
+        AgendamentoFrame frame = new AgendamentoFrame();
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
## Summary
- show a small form in Swing for scheduling consultations/exams
- launch the new `AgendamentoFrame` from `SwingApp`
- document Swing scheduling form in README

## Testing
- `mkdir -p out && javac -d out $(find src/main/java -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_684b32917e708320bac9fa3ecc1d7002