### PR TITLE
Add environment variable config for DB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Exemplo de configuração do banco de dados
+DB_URL=jdbc:mysql://localhost:3306/uniclinicavet
+DB_USER=root
+DB_PASS=senha

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 .idea/
 target/
+.env

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Este projeto oferece uma arquitetura inicial em Java para gerenciar tutores, animais, consultas e exames. A camada de persistência é feita com MySQL via JDBC.
 
-A classe `DBConnection` possui os dados de acesso ao banco de dados definidos diretamente no código. Ajuste as constantes `URL`, `USER` e `PASS` conforme a sua instalação do MySQL.
+A configuração de acesso ao banco é lida de variáveis de ambiente. Crie um arquivo `.env` na raiz com as chaves `DB_URL`, `DB_USER` e `DB_PASS` ou defina-as no seu sistema.
 
 ## Estrutura de Pastas
 ```
@@ -15,8 +15,12 @@ src/
         service/     # Regras de negócio
         controller/  # Ponto de entrada e controladores
         util/        # Utilidades (ex: conexões)
-    resources/       # Recursos adicionais
+  resources/       # Recursos adicionais
 ```
+
+## Configuração do Banco de Dados
+
+Copie o arquivo `.env.example` para `.env` e ajuste as variáveis `DB_URL`, `DB_USER` e `DB_PASS` de acordo com o seu ambiente de MySQL. Esses valores também podem ser definidos como variáveis de ambiente do sistema.
 
 ## Compilação
 Utilize o JDK (versão 17 ou superior) para compilar manualmente os arquivos fonte.

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,12 @@
     </properties>
 
     <dependencies>
-        <!-- Nenhuma dependência externa é necessária para a interface Swing -->
+        <!-- Biblioteca para carregar variáveis do arquivo .env -->
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/uniclinica/util/DBConnection.java
+++ b/src/main/java/com/uniclinica/util/DBConnection.java
@@ -3,20 +3,21 @@ package com.uniclinica.util;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import io.github.cdimascio.dotenv.Dotenv;
 
 
 public class DBConnection {
 
     private DBConnection() {}
 
-    private static final String URL = "jdbc:mysql://localhost:3306/uniclinicavet";
-    private static final String USER = "root"; // ajuste conforme suas credenciais
-    private static final String PASS = "";     // ajuste conforme suas credenciais
+    private static final Dotenv dotenv = Dotenv.configure()
+            .ignoreIfMissing()
+            .load();
 
     public static Connection getConnection() {
-        String url = URL;
-        String user = USER;
-        String pass = PASS;
+        String url = dotenv.get("DB_URL", "jdbc:mysql://localhost:3306/uniclinicavet");
+        String user = dotenv.get("DB_USER", "root");
+        String pass = dotenv.get("DB_PASS", "");
         try {
             return DriverManager.getConnection(url, user, pass);
         } catch (SQLException e) {


### PR DESCRIPTION
## Summary
- load DB configuration from `.env`
- add example `.env` file and ignore real one
- document configuration in README
- include `dotenv-java` dependency

## Testing
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684b3e6e9d1c83209f988715484c897b