### PR TITLE
Support running Swing without Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,35 @@ Copie o arquivo `.env.example` para `.env` e ajuste as variáveis `DB_URL`, `DB_
 
 ## Compilação
 Utilize o JDK (versão 17 ou superior) para compilar manualmente os arquivos fonte.
-Para rodar somente a aplicação de console, compile todas as classes Java
-incluindo as dependências (ex.: usando Maven para copiar os jars):
+Se preferir dispensar o Maven, baixe a biblioteca `dotenv-java` para a pasta `lib/`
+e a inclua no classpath:
 
 ```bash
-javac -cp "target/dependency/*" -d out $(find src/main/java -name '*.java')
-java -cp "target/dependency/*:out" com.uniclinica.controller.App
+curl -L -o lib/dotenv-java-3.2.0.jar \
+  https://repo1.maven.org/maven2/io/github/cdimascio/dotenv-java/3.2.0/dotenv-java-3.2.0.jar
+```
+
+```bash
+javac -cp "lib/*" -d out $(find src/main/java -name '*.java')
+java -cp "lib/*:out" com.uniclinica.controller.App
 ```
 
 Para abrir a interface Swing com um pequeno formulário de agendamento basta executar a classe `SwingApp`:
 
 ```bash
-javac -cp "target/dependency/*" -d out $(find src/main/java -name '*.java')
-java -cp "target/dependency/*:out" com.uniclinica.controller.SwingApp
+javac -cp "lib/*" -d out $(find src/main/java -name '*.java')
+java -cp "lib/*:out" com.uniclinica.controller.SwingApp
 ```
 
 ### Execução rápida com scripts
 
-O repositório inclui scripts Bash que utilizam o Maven para compilar e executar o projeto:
+O repositório inclui scripts Bash para facilitar a execução. Os arquivos `run.sh` e `run_swing.sh`
+utilizam o Maven, enquanto `run_swing_nomaven.sh` baixa a dependência `dotenv-java` e roda a interface sem Maven:
 
 ```bash
-./run.sh            # executa a aplicação de console
-./run_swing.sh      # abre a interface Swing
+./run.sh                 # executa a aplicação de console (via Maven)
+./run_swing.sh           # abre a interface Swing (via Maven)
+./run_swing_nomaven.sh   # baixa o jar necessário e executa a interface sem Maven
 ```
 
 ### Execução rápida com Maven
@@ -69,11 +76,11 @@ objetivos `exec:java`.
 
 ### Executar interface Swing manualmente
 
-Caso deseje rodar a interface gráfica sem o script, compile e execute a classe `SwingApp`:
+Caso deseje rodar a interface gráfica sem Maven nem scripts, compile e execute a classe `SwingApp`:
 
 ```bash
-javac -cp "target/dependency/*" -d out $(find src/main/java -name '*.java')
-java -cp "target/dependency/*:out" com.uniclinica.controller.SwingApp
+javac -cp "lib/*" -d out $(find src/main/java -name '*.java')
+java -cp "lib/*:out" com.uniclinica.controller.SwingApp
 ```
 
 Ao executar, uma janela exibindo um formulário de agendamento de consultas e exames será apresentada.

--- a/run_swing_nomaven.sh
+++ b/run_swing_nomaven.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+JAR_DIR="lib"
+JAR_NAME="dotenv-java-3.2.0.jar"
+JAR_PATH="$JAR_DIR/$JAR_NAME"
+JAR_URL="https://repo1.maven.org/maven2/io/github/cdimascio/dotenv-java/3.2.0/$JAR_NAME"
+
+mkdir -p "$JAR_DIR"
+if [ ! -f "$JAR_PATH" ]; then
+  echo "Baixando dependencia $JAR_NAME..."
+  curl -L -o "$JAR_PATH" "$JAR_URL"
+fi
+
+mkdir -p out
+echo "Compilando fontes..."
+javac -cp "$JAR_DIR/*" -d out $(find src/main/java -name '*.java')
+
+echo "Iniciando aplicativo Swing..."
+java -cp "$JAR_DIR/*:out" com.uniclinica.controller.SwingApp


### PR DESCRIPTION
## Summary
- add `run_swing_nomaven.sh` script to download dependency jar and run Swing app without Maven
- document how to compile manually using `lib/*`
- mention new script as an alternative to the Maven scripts

## Testing
- `./run_swing_nomaven.sh` *(fails: no DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684b506de6448320ae310cfc4227b907