### PR TITLE
Add admin CRUD UI and JDBC implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,28 +24,38 @@ Copie o arquivo `.env.example` para `.env` e ajuste as variáveis `DB_URL`, `DB_
 
 ## Compilação
 Utilize o JDK (versão 17 ou superior) para compilar manualmente os arquivos fonte.
-Para rodar somente a aplicação de console, compile todas as classes Java
-incluindo as dependências (ex.: usando Maven para copiar os jars):
+Se preferir dispensar o Maven, baixe a biblioteca `dotenv-java` para a pasta `lib/`
+e a inclua no classpath:
 
 ```bash
-javac -cp "target/dependency/*" -d out $(find src/main/java -name '*.java')
-java -cp "target/dependency/*:out" com.uniclinica.controller.App
+curl -L -o lib/dotenv-java-3.2.0.jar \
+  https://repo1.maven.org/maven2/io/github/cdimascio/dotenv-java/3.2.0/dotenv-java-3.2.0.jar
+```
+
+```bash
+javac -cp "lib/*" -d out $(find src/main/java -name '*.java')
+# use ';' instead of ':' on Windows
+java -cp "lib/*:out" com.uniclinica.controller.App
 ```
 
 Para abrir a interface Swing com um pequeno formulário de agendamento basta executar a classe `SwingApp`:
 
 ```bash
-javac -cp "target/dependency/*" -d out $(find src/main/java -name '*.java')
-java -cp "target/dependency/*:out" com.uniclinica.controller.SwingApp
+javac -cp "lib/*" -d out $(find src/main/java -name '*.java')
+# use ';' instead of ':' on Windows
+java -cp "lib/*:out" com.uniclinica.controller.SwingApp
 ```
 
 ### Execução rápida com scripts
 
-O repositório inclui scripts Bash que utilizam o Maven para compilar e executar o projeto:
+O repositório inclui scripts Bash para facilitar a execução. Os arquivos `run.sh` e `run_swing.sh`
+utilizam o Maven, enquanto `run_swing_nomaven.sh` baixa a dependência `dotenv-java` e roda a interface sem Maven.
+Execute-os dentro de um terminal **Bash** (ex.: Git Bash no Windows) para evitar que a janela se feche imediatamente em caso de erro:
 
 ```bash
-./run.sh            # executa a aplicação de console
-./run_swing.sh      # abre a interface Swing
+./run.sh                 # executa a aplicação de console (via Maven)
+./run_swing.sh           # abre a interface Swing (via Maven)
+./run_swing_nomaven.sh   # baixa o jar necessário e executa a interface sem Maven
 ```
 
 ### Execução rápida com Maven
@@ -69,15 +79,15 @@ objetivos `exec:java`.
 
 ### Executar interface Swing manualmente
 
-Caso deseje rodar a interface gráfica sem o script, compile e execute a classe `SwingApp`:
+Caso deseje rodar a interface gráfica sem Maven nem scripts, compile e execute a classe `SwingApp`:
 
 ```bash
-javac -cp "target/dependency/*" -d out $(find src/main/java -name '*.java')
-java -cp "target/dependency/*:out" com.uniclinica.controller.SwingApp
+javac -cp "lib/*" -d out $(find src/main/java -name '*.java')
+# use ';' instead of ':' on Windows
+java -cp "lib/*:out" com.uniclinica.controller.SwingApp
 ```
 
-Ao executar, uma janela exibindo um formulário de agendamento de consultas e exames será apresentada.
+Ao executar, uma janela com duas abas será apresentada: **Agendamento**, que permite marcar consultas e exames, e **Admin**, onde é possível realizar operações de CRUD para tutores, animais, consultas e exames. Todas as ações utilizam um banco MySQL configurado via `.env`.
 
 ## Próximos Passos
-1. Implementar as classes de DAO utilizando JDBC.
-2. Expandir a interface em Swing.
+1. Melhorar a validação de dados e a usabilidade da interface.

--- a/run_swing_nomaven.sh
+++ b/run_swing_nomaven.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Ajusta separador do classpath conforme o sistema operacional
+CP_SEP=":"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) CP_SEP=";" ;;
+  *) CP_SEP=":" ;;
+esac
+
+JAR_DIR="lib"
+JAR_NAME="dotenv-java-3.2.0.jar"
+JAR_PATH="$JAR_DIR/$JAR_NAME"
+JAR_URL="https://repo1.maven.org/maven2/io/github/cdimascio/dotenv-java/3.2.0/$JAR_NAME"
+
+mkdir -p "$JAR_DIR"
+if [ ! -f "$JAR_PATH" ]; then
+  echo "Baixando dependencia $JAR_NAME..."
+  curl -L -o "$JAR_PATH" "$JAR_URL"
+fi
+
+mkdir -p out
+echo "Compilando fontes..."
+javac -cp "$JAR_DIR/*" -d out $(find src/main/java -name '*.java')
+
+echo "Iniciando aplicativo Swing..."
+java -cp "$JAR_DIR/*${CP_SEP}out" com.uniclinica.controller.SwingApp
+
+# Em ambientes Windows, mantenha a janela aberta para o usuário ver mensagens
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) read -rp "Pressione Enter para sair" _ ;;
+esac

--- a/src/main/java/com/uniclinica/controller/AdminPanel.java
+++ b/src/main/java/com/uniclinica/controller/AdminPanel.java
@@ -1,0 +1,240 @@
+package com.uniclinica.controller;
+
+import com.uniclinica.model.*;
+import com.uniclinica.service.*;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Painel de administração com abas para cada entidade.
+ */
+public class AdminPanel extends JPanel {
+
+    public AdminPanel() {
+        setLayout(new BorderLayout());
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.addTab("Tutores", new TutorCrudPanel());
+        tabs.addTab("Animais", new AnimalCrudPanel());
+        tabs.addTab("Consultas", new ConsultaCrudPanel());
+        tabs.addTab("Exames", new ExameCrudPanel());
+        add(tabs, BorderLayout.CENTER);
+    }
+
+    // Painel CRUD de Tutor
+    private static class TutorCrudPanel extends JPanel {
+        private final TutorService service = new TutorService();
+        private final JTextField id = new JTextField(5);
+        private final JTextField nome = new JTextField(15);
+        private final JTextField tel = new JTextField(10);
+        private final JTextField email = new JTextField(15);
+        private final JTextArea out = new JTextArea();
+
+        TutorCrudPanel() {
+            setLayout(new BorderLayout(5,5));
+            JPanel form = new JPanel(new GridLayout(0,2,5,5));
+            form.add(new JLabel("ID:"));
+            form.add(id);
+            form.add(new JLabel("Nome:"));
+            form.add(nome);
+            form.add(new JLabel("Telefone:"));
+            form.add(tel);
+            form.add(new JLabel("Email:"));
+            form.add(email);
+
+            JPanel btns = new JPanel();
+            JButton add = new JButton("Adicionar");
+            add.addActionListener(e -> {
+                service.cadastrarTutor(new Tutor(0,nome.getText(),tel.getText(),email.getText()));
+                listar();
+            });
+            JButton upd = new JButton("Atualizar");
+            upd.addActionListener(e -> {
+                service.atualizarTutor(new Tutor(Integer.parseInt(id.getText()),nome.getText(),tel.getText(),email.getText()));
+                listar();
+            });
+            JButton del = new JButton("Remover");
+            del.addActionListener(e -> {
+                service.removerTutor(Integer.parseInt(id.getText()));
+                listar();
+            });
+            JButton list = new JButton("Listar");
+            list.addActionListener(e -> listar());
+            btns.add(add);btns.add(upd);btns.add(del);btns.add(list);
+
+            add(form, BorderLayout.NORTH);
+            add(btns, BorderLayout.CENTER);
+            out.setEditable(false);
+            add(new JScrollPane(out), BorderLayout.SOUTH);
+            listar();
+        }
+        private void listar() {
+            List<Tutor> t = service.listarTutores();
+            out.setText("");
+            for (Tutor tu : t) {
+                out.append(tu.getId()+" - "+tu.getNome()+"\n");
+            }
+        }
+    }
+
+    // Painel CRUD de Animal
+    private static class AnimalCrudPanel extends JPanel {
+        private final AnimalService service = new AnimalService();
+        private final JTextField id = new JTextField(5);
+        private final JTextField tutorId = new JTextField(5);
+        private final JTextField nome = new JTextField(10);
+        private final JTextField especie = new JTextField(10);
+        private final JTextField raca = new JTextField(10);
+        private final JTextField nasc = new JTextField("yyyy-MM-dd",10);
+        private final JTextArea out = new JTextArea();
+        AnimalCrudPanel(){
+            setLayout(new BorderLayout(5,5));
+            JPanel form = new JPanel(new GridLayout(0,2,5,5));
+            form.add(new JLabel("ID:"));form.add(id);
+            form.add(new JLabel("TutorId:"));form.add(tutorId);
+            form.add(new JLabel("Nome:"));form.add(nome);
+            form.add(new JLabel("Espécie:"));form.add(especie);
+            form.add(new JLabel("Raça:"));form.add(raca);
+            form.add(new JLabel("Nascimento:"));form.add(nasc);
+
+            JPanel btns = new JPanel();
+            JButton add = new JButton("Adicionar");
+            add.addActionListener(e->{
+                service.cadastrarAnimal(new Animal(0,Integer.parseInt(tutorId.getText()),nome.getText(),especie.getText(),raca.getText(),LocalDate.parse(nasc.getText())));
+                listar();
+            });
+            JButton upd = new JButton("Atualizar");
+            upd.addActionListener(e->{
+                service.atualizarAnimal(new Animal(Integer.parseInt(id.getText()),Integer.parseInt(tutorId.getText()),nome.getText(),especie.getText(),raca.getText(),LocalDate.parse(nasc.getText())));
+                listar();
+            });
+            JButton del = new JButton("Remover");
+            del.addActionListener(e->{ service.removerAnimal(Integer.parseInt(id.getText())); listar();});
+            JButton list = new JButton("Listar");
+            list.addActionListener(e->listar());
+            btns.add(add);btns.add(upd);btns.add(del);btns.add(list);
+
+            add(form,BorderLayout.NORTH);
+            add(btns,BorderLayout.CENTER);
+            out.setEditable(false);
+            add(new JScrollPane(out),BorderLayout.SOUTH);
+            listar();
+        }
+        private void listar(){
+            List<Animal> list=service.listarAnimais();
+            out.setText("");
+            for(Animal a:list){
+                out.append(a.getId()+" - "+a.getNome()+"\n");
+            }
+        }
+    }
+
+    // Painel CRUD de Consulta
+    private static class ConsultaCrudPanel extends JPanel {
+        private final ConsultaService service = new ConsultaService();
+        private final JTextField id = new JTextField(5);
+        private final JTextField animalId = new JTextField(5);
+        private final JTextField data = new JTextField("yyyy-MM-dd HH:mm",15);
+        private final JTextField vet = new JTextField(10);
+        private final JTextField diag = new JTextField(10);
+        private final JTextArea out = new JTextArea();
+        ConsultaCrudPanel(){
+            setLayout(new BorderLayout(5,5));
+            JPanel form=new JPanel(new GridLayout(0,2,5,5));
+            form.add(new JLabel("ID:"));form.add(id);
+            form.add(new JLabel("AnimalId:"));form.add(animalId);
+            form.add(new JLabel("DataHora:"));form.add(data);
+            form.add(new JLabel("Veterinário:"));form.add(vet);
+            form.add(new JLabel("Diagnóstico:"));form.add(diag);
+
+            JPanel btns=new JPanel();
+            JButton add=new JButton("Adicionar");
+            add.addActionListener(e->{
+                LocalDateTime dt=LocalDateTime.parse(data.getText(),DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+                service.agendarConsulta(new Consulta(0,Integer.parseInt(animalId.getText()),dt,vet.getText(),diag.getText()));
+                listar();
+            });
+            JButton upd=new JButton("Atualizar");
+            upd.addActionListener(e->{
+                LocalDateTime dt=LocalDateTime.parse(data.getText(),DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+                service.atualizarConsulta(new Consulta(Integer.parseInt(id.getText()),Integer.parseInt(animalId.getText()),dt,vet.getText(),diag.getText()));
+                listar();
+            });
+            JButton del=new JButton("Remover");
+            del.addActionListener(e->{ service.cancelarConsulta(Integer.parseInt(id.getText())); listar(); });
+            JButton list=new JButton("Listar");
+            list.addActionListener(e->listar());
+            btns.add(add);btns.add(upd);btns.add(del);btns.add(list);
+
+            add(form,BorderLayout.NORTH);
+            add(btns,BorderLayout.CENTER);
+            out.setEditable(false);
+            add(new JScrollPane(out),BorderLayout.SOUTH);
+            listar();
+        }
+        private void listar(){
+            List<Consulta> list=service.listarConsultas();
+            out.setText("");
+            for(Consulta c:list){
+                out.append(c.getId()+" - "+c.getVeterinario()+"\n");
+            }
+        }
+    }
+
+    // Painel CRUD de Exame
+    private static class ExameCrudPanel extends JPanel {
+        private final ExameService service = new ExameService();
+        private final JTextField id = new JTextField(5);
+        private final JTextField consultaId = new JTextField(5);
+        private final JTextField tipo = new JTextField(10);
+        private final JTextField status = new JTextField(10);
+        private final JTextField entrega = new JTextField("yyyy-MM-dd",10);
+        private final JTextArea out = new JTextArea();
+        ExameCrudPanel(){
+            setLayout(new BorderLayout(5,5));
+            JPanel form=new JPanel(new GridLayout(0,2,5,5));
+            form.add(new JLabel("ID:"));form.add(id);
+            form.add(new JLabel("ConsultaId:"));form.add(consultaId);
+            form.add(new JLabel("Tipo:"));form.add(tipo);
+            form.add(new JLabel("Status:"));form.add(status);
+            form.add(new JLabel("Entrega:"));form.add(entrega);
+
+            JPanel btns=new JPanel();
+            JButton add=new JButton("Adicionar");
+            add.addActionListener(e->{
+                LocalDate d=LocalDate.parse(entrega.getText());
+                service.solicitarExame(new Exame(0,Integer.parseInt(consultaId.getText()),tipo.getText(),status.getText(),d));
+                listar();
+            });
+            JButton upd=new JButton("Atualizar");
+            upd.addActionListener(e->{
+                LocalDate d=LocalDate.parse(entrega.getText());
+                service.atualizarExame(new Exame(Integer.parseInt(id.getText()),Integer.parseInt(consultaId.getText()),tipo.getText(),status.getText(),d));
+                listar();
+            });
+            JButton del=new JButton("Remover");
+            del.addActionListener(e->{ service.removerExame(Integer.parseInt(id.getText())); listar();});
+            JButton list=new JButton("Listar");
+            list.addActionListener(e->listar());
+            btns.add(add);btns.add(upd);btns.add(del);btns.add(list);
+
+            add(form,BorderLayout.NORTH);
+            add(btns,BorderLayout.CENTER);
+            out.setEditable(false);
+            add(new JScrollPane(out),BorderLayout.SOUTH);
+            listar();
+        }
+        private void listar(){
+            List<Exame> list=service.listarExames();
+            out.setText("");
+            for(Exame ex:list){
+                out.append(ex.getId()+" - "+ex.getTipo()+"\n");
+            }
+        }
+    }
+}

--- a/src/main/java/com/uniclinica/controller/AgendamentoPanel.java
+++ b/src/main/java/com/uniclinica/controller/AgendamentoPanel.java
@@ -8,9 +8,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import com.uniclinica.model.*;
+import com.uniclinica.service.*;
 
 
-public class AgendamentoFrame extends JFrame {
+public class AgendamentoPanel extends JPanel {
 
     private final JTextField tutorField = new JTextField();
     private final JTextField animalField = new JTextField();
@@ -19,13 +21,11 @@ public class AgendamentoFrame extends JFrame {
     private final JTextField veterinarioField = new JTextField();
     private final JTextField exameField = new JTextField();
     private final JTextArea outputArea = new JTextArea();
+    private final ConsultaService consultaService = new ConsultaService();
+    private final ExameService exameService = new ExameService();
 
-    public AgendamentoFrame() {
-        super("Agendar Consulta/Exame");
-        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    public AgendamentoPanel() {
         createLayout();
-        pack();
-        setLocationRelativeTo(null);
     }
 
     private void createLayout() {
@@ -54,9 +54,9 @@ public class AgendamentoFrame extends JFrame {
         JScrollPane scroll = new JScrollPane(outputArea);
         scroll.setPreferredSize(new Dimension(400, 200));
 
-        getContentPane().setLayout(new BorderLayout(5, 5));
-        getContentPane().add(top, BorderLayout.NORTH);
-        getContentPane().add(scroll, BorderLayout.CENTER);
+        setLayout(new BorderLayout(5, 5));
+        add(top, BorderLayout.NORTH);
+        add(scroll, BorderLayout.CENTER);
     }
 
     private class ScheduleListener implements ActionListener {
@@ -71,6 +71,13 @@ public class AgendamentoFrame extends JFrame {
                 String exame = exameField.getText();
                 LocalDateTime dt = LocalDateTime.of(data, hora);
 
+                Consulta consulta = new Consulta(0, Integer.parseInt(animal), dt, vet, "");
+                consultaService.agendarConsulta(consulta);
+                if (!exame.isBlank()) {
+                    Exame ex = new Exame(0, consulta.getId(), exame, "Pendente", null);
+                    exameService.solicitarExame(ex);
+                }
+
                 String resumo = String.format("%s - %s\n  Consulta: %s com %s\n  Exame: %s\n", tutor, animal, dt, vet, exame);
                 outputArea.append(resumo + "\n");
 
@@ -82,7 +89,7 @@ public class AgendamentoFrame extends JFrame {
                 veterinarioField.setText("");
                 exameField.setText("");
             } catch (Exception ex) {
-                JOptionPane.showMessageDialog(AgendamentoFrame.this,
+                JOptionPane.showMessageDialog(AgendamentoPanel.this,
                         "Dados inválidos: " + ex.getMessage(),
                         "Erro", JOptionPane.ERROR_MESSAGE);
             }

--- a/src/main/java/com/uniclinica/controller/MainFrame.java
+++ b/src/main/java/com/uniclinica/controller/MainFrame.java
@@ -1,0 +1,22 @@
+package com.uniclinica.controller;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Janela principal com abas de agendamento e administração.
+ */
+public class MainFrame extends JFrame {
+
+    public MainFrame() {
+        super("UniClinicaVet");
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        setLayout(new BorderLayout());
+        JTabbedPane tabs = new JTabbedPane();
+        tabs.addTab("Agendamento", new AgendamentoPanel());
+        tabs.addTab("Admin", new AdminPanel());
+        add(tabs, BorderLayout.CENTER);
+        pack();
+        setLocationRelativeTo(null);
+    }
+}

--- a/src/main/java/com/uniclinica/controller/SwingApp.java
+++ b/src/main/java/com/uniclinica/controller/SwingApp.java
@@ -1,13 +1,12 @@
 package com.uniclinica.controller;
 
 import javax.swing.SwingUtilities;
-import com.uniclinica.controller.AgendamentoFrame;
-
+import com.uniclinica.controller.MainFrame;
 
 public class SwingApp {
 
     private static void createAndShowGui() {
-        AgendamentoFrame frame = new AgendamentoFrame();
+        MainFrame frame = new MainFrame();
         frame.setVisible(true);
     }
 

--- a/src/main/java/com/uniclinica/dao/AnimalDao.java
+++ b/src/main/java/com/uniclinica/dao/AnimalDao.java
@@ -1,6 +1,9 @@
 package com.uniclinica.dao;
 
 import com.uniclinica.model.Animal;
+import com.uniclinica.util.DBConnection;
+import java.sql.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,19 +13,93 @@ import java.util.List;
 public class AnimalDao {
 
     public List<Animal> findByTutor(int tutorId) {
-        // TODO implementar consulta ao banco
-        return new ArrayList<>();
+        List<Animal> list = new ArrayList<>();
+        String sql = "SELECT id, tutor_id, nome, especie, raca, data_nascimento FROM animal WHERE tutor_id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, tutorId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar animais", e);
+        }
+        return list;
+    }
+
+    public List<Animal> findAll() {
+        List<Animal> list = new ArrayList<>();
+        String sql = "SELECT id, tutor_id, nome, especie, raca, data_nascimento FROM animal";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar animais", e);
+        }
+        return list;
     }
 
     public void save(Animal animal) {
-        // TODO inserir animal no banco
+        String sql = "INSERT INTO animal (tutor_id, nome, especie, raca, data_nascimento) VALUES (?,?,?,?,?)";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, animal.getTutorId());
+            ps.setString(2, animal.getNome());
+            ps.setString(3, animal.getEspecie());
+            ps.setString(4, animal.getRaca());
+            ps.setDate(5, Date.valueOf(animal.getDataNascimento()));
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    animal.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao salvar animal", e);
+        }
     }
 
     public void update(Animal animal) {
-        // TODO atualizar animal no banco
+        String sql = "UPDATE animal SET tutor_id=?, nome=?, especie=?, raca=?, data_nascimento=? WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, animal.getTutorId());
+            ps.setString(2, animal.getNome());
+            ps.setString(3, animal.getEspecie());
+            ps.setString(4, animal.getRaca());
+            ps.setDate(5, Date.valueOf(animal.getDataNascimento()));
+            ps.setInt(6, animal.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao atualizar animal", e);
+        }
     }
 
     public void delete(int id) {
-        // TODO remover animal do banco
+        String sql = "DELETE FROM animal WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao remover animal", e);
+        }
+    }
+
+    private Animal map(ResultSet rs) throws SQLException {
+        Animal a = new Animal();
+        a.setId(rs.getInt("id"));
+        a.setTutorId(rs.getInt("tutor_id"));
+        a.setNome(rs.getString("nome"));
+        a.setEspecie(rs.getString("especie"));
+        a.setRaca(rs.getString("raca"));
+        Date d = rs.getDate("data_nascimento");
+        if (d != null) a.setDataNascimento(d.toLocalDate());
+        return a;
     }
 }

--- a/src/main/java/com/uniclinica/dao/ConsultaDao.java
+++ b/src/main/java/com/uniclinica/dao/ConsultaDao.java
@@ -1,6 +1,9 @@
 package com.uniclinica.dao;
 
 import com.uniclinica.model.Consulta;
+import com.uniclinica.util.DBConnection;
+import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,19 +13,90 @@ import java.util.List;
 public class ConsultaDao {
 
     public List<Consulta> findByAnimal(int animalId) {
-        // TODO implementar consulta ao banco
-        return new ArrayList<>();
+        List<Consulta> list = new ArrayList<>();
+        String sql = "SELECT id, animal_id, data_hora, veterinario, diagnostico FROM consulta WHERE animal_id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, animalId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar consultas", e);
+        }
+        return list;
+    }
+
+    public List<Consulta> findAll() {
+        List<Consulta> list = new ArrayList<>();
+        String sql = "SELECT id, animal_id, data_hora, veterinario, diagnostico FROM consulta";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar consultas", e);
+        }
+        return list;
     }
 
     public void save(Consulta consulta) {
-        // TODO inserir consulta no banco
+        String sql = "INSERT INTO consulta (animal_id, data_hora, veterinario, diagnostico) VALUES (?,?,?,?)";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, consulta.getAnimalId());
+            ps.setTimestamp(2, Timestamp.valueOf(consulta.getDataHora()));
+            ps.setString(3, consulta.getVeterinario());
+            ps.setString(4, consulta.getDiagnostico());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    consulta.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao salvar consulta", e);
+        }
     }
 
     public void update(Consulta consulta) {
-        // TODO atualizar consulta no banco
+        String sql = "UPDATE consulta SET animal_id=?, data_hora=?, veterinario=?, diagnostico=? WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, consulta.getAnimalId());
+            ps.setTimestamp(2, Timestamp.valueOf(consulta.getDataHora()));
+            ps.setString(3, consulta.getVeterinario());
+            ps.setString(4, consulta.getDiagnostico());
+            ps.setInt(5, consulta.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao atualizar consulta", e);
+        }
     }
 
     public void delete(int id) {
-        // TODO remover consulta do banco
+        String sql = "DELETE FROM consulta WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao remover consulta", e);
+        }
+    }
+
+    private Consulta map(ResultSet rs) throws SQLException {
+        Consulta c = new Consulta();
+        c.setId(rs.getInt("id"));
+        c.setAnimalId(rs.getInt("animal_id"));
+        Timestamp ts = rs.getTimestamp("data_hora");
+        if (ts != null) c.setDataHora(ts.toLocalDateTime());
+        c.setVeterinario(rs.getString("veterinario"));
+        c.setDiagnostico(rs.getString("diagnostico"));
+        return c;
     }
 }

--- a/src/main/java/com/uniclinica/dao/ExameDao.java
+++ b/src/main/java/com/uniclinica/dao/ExameDao.java
@@ -1,6 +1,9 @@
 package com.uniclinica.dao;
 
 import com.uniclinica.model.Exame;
+import com.uniclinica.util.DBConnection;
+import java.sql.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,19 +13,94 @@ import java.util.List;
 public class ExameDao {
 
     public List<Exame> findByConsulta(int consultaId) {
-        // TODO implementar consulta ao banco
-        return new ArrayList<>();
+        List<Exame> list = new ArrayList<>();
+        String sql = "SELECT id, consulta_id, tipo, status, data_entrega FROM exame WHERE consulta_id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, consultaId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    list.add(map(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar exames", e);
+        }
+        return list;
+    }
+
+    public List<Exame> findAll() {
+        List<Exame> list = new ArrayList<>();
+        String sql = "SELECT id, consulta_id, tipo, status, data_entrega FROM exame";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                list.add(map(rs));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar exames", e);
+        }
+        return list;
     }
 
     public void save(Exame exame) {
-        // TODO inserir exame no banco
+        String sql = "INSERT INTO exame (consulta_id, tipo, status, data_entrega) VALUES (?,?,?,?)";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, exame.getConsultaId());
+            ps.setString(2, exame.getTipo());
+            ps.setString(3, exame.getStatus());
+            if (exame.getDataEntrega() != null)
+                ps.setDate(4, Date.valueOf(exame.getDataEntrega()));
+            else
+                ps.setNull(4, Types.DATE);
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) exame.setId(rs.getInt(1));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao salvar exame", e);
+        }
     }
 
     public void update(Exame exame) {
-        // TODO atualizar exame no banco
+        String sql = "UPDATE exame SET consulta_id=?, tipo=?, status=?, data_entrega=? WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, exame.getConsultaId());
+            ps.setString(2, exame.getTipo());
+            ps.setString(3, exame.getStatus());
+            if (exame.getDataEntrega() != null)
+                ps.setDate(4, Date.valueOf(exame.getDataEntrega()));
+            else
+                ps.setNull(4, Types.DATE);
+            ps.setInt(5, exame.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao atualizar exame", e);
+        }
     }
 
     public void delete(int id) {
-        // TODO remover exame do banco
+        String sql = "DELETE FROM exame WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao remover exame", e);
+        }
+    }
+
+    private Exame map(ResultSet rs) throws SQLException {
+        Exame e = new Exame();
+        e.setId(rs.getInt("id"));
+        e.setConsultaId(rs.getInt("consulta_id"));
+        e.setTipo(rs.getString("tipo"));
+        e.setStatus(rs.getString("status"));
+        Date d = rs.getDate("data_entrega");
+        if (d != null) e.setDataEntrega(d.toLocalDate());
+        return e;
     }
 }

--- a/src/main/java/com/uniclinica/dao/TutorDao.java
+++ b/src/main/java/com/uniclinica/dao/TutorDao.java
@@ -1,6 +1,8 @@
 package com.uniclinica.dao;
 
 import com.uniclinica.model.Tutor;
+import com.uniclinica.util.DBConnection;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,19 +12,65 @@ import java.util.List;
 public class TutorDao {
 
     public List<Tutor> findAll() {
-        // TODO implementar consulta ao banco
-        return new ArrayList<>();
+        List<Tutor> list = new ArrayList<>();
+        String sql = "SELECT id, nome, telefone, email FROM tutor";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                Tutor t = new Tutor();
+                t.setId(rs.getInt("id"));
+                t.setNome(rs.getString("nome"));
+                t.setTelefone(rs.getString("telefone"));
+                t.setEmail(rs.getString("email"));
+                list.add(t);
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao listar tutores", e);
+        }
+        return list;
     }
 
     public void save(Tutor tutor) {
-        // TODO inserir tutor no banco
+        String sql = "INSERT INTO tutor (nome, telefone, email) VALUES (?, ?, ?)";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setString(1, tutor.getNome());
+            ps.setString(2, tutor.getTelefone());
+            ps.setString(3, tutor.getEmail());
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    tutor.setId(rs.getInt(1));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao salvar tutor", e);
+        }
     }
 
     public void update(Tutor tutor) {
-        // TODO atualizar tutor no banco
+        String sql = "UPDATE tutor SET nome=?, telefone=?, email=? WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, tutor.getNome());
+            ps.setString(2, tutor.getTelefone());
+            ps.setString(3, tutor.getEmail());
+            ps.setInt(4, tutor.getId());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao atualizar tutor", e);
+        }
     }
 
     public void delete(int id) {
-        // TODO remover tutor do banco
+        String sql = "DELETE FROM tutor WHERE id=?";
+        try (Connection c = DBConnection.getConnection();
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Erro ao remover tutor", e);
+        }
     }
 }

--- a/src/main/java/com/uniclinica/service/AnimalService.java
+++ b/src/main/java/com/uniclinica/service/AnimalService.java
@@ -7,6 +7,10 @@ import java.util.List;
 public class AnimalService {
     private final AnimalDao dao = new AnimalDao();
 
+    public List<Animal> listarAnimais() {
+        return dao.findAll();
+    }
+
     public List<Animal> listarPorTutor(int tutorId) {
         return dao.findByTutor(tutorId);
     }

--- a/src/main/java/com/uniclinica/service/ConsultaService.java
+++ b/src/main/java/com/uniclinica/service/ConsultaService.java
@@ -7,6 +7,10 @@ import java.util.List;
 public class ConsultaService {
     private final ConsultaDao dao = new ConsultaDao();
 
+    public List<Consulta> listarConsultas() {
+        return dao.findAll();
+    }
+
     public List<Consulta> listarPorAnimal(int animalId) {
         return dao.findByAnimal(animalId);
     }

--- a/src/main/java/com/uniclinica/service/ExameService.java
+++ b/src/main/java/com/uniclinica/service/ExameService.java
@@ -7,6 +7,10 @@ import java.util.List;
 public class ExameService {
     private final ExameDao dao = new ExameDao();
 
+    public List<Exame> listarExames() {
+        return dao.findAll();
+    }
+
     public List<Exame> listarPorConsulta(int consultaId) {
         return dao.findByConsulta(consultaId);
     }


### PR DESCRIPTION
## Summary
- turn Agendamento into a panel and create MainFrame with Admin tab
- implement JDBC CRUD operations for all entities
- add AdminPanel with tabs for Tutor, Animal, Consulta and Exame
- wire scheduling panel to persist consultas e exames
- document new GUI tabs in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*
- `mvn -q exec:java` *(fails: command not found)*
- `bash run_swing_nomaven.sh` *(fails: headless environment)*
- `javac -cp "lib/*" -d out @/tmp/sources`

------
https://chatgpt.com/codex/tasks/task_e_684b506de6448320ae310cfc4227b907